### PR TITLE
bridge_infill and menu fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This is mandatory, whatever the slicer you use:
     [save_variables]
     filename: ~/klipper_config/saved_variables.cfg
     ```
-2. Copy the content of [`fast_infill.cfg`](klipper/fast_infill.cfg) into your `printer.cfg`
-3. If you use a standard screen (not KlipperScreen), you can also add the content of [`menu_fast_infill.cfg`](klipper/menu_fast_infill.cfg). This will add 2 entries in your `Tune` menu to be able to set some values without going to the fluidd/mainsail interface
-4. Once you have added the configuration to your klipper configuration, restart Klipper
+2. Copy the content of [`fast_infill.cfg`](klipper/fast_infill.cfg) into your `printer.cfg`.
+3. If you use a standard screen (not KlipperScreen), you can also add the content of [`menu_fast_infill.cfg`](klipper/menu_fast_infill.cfg). This will add a new "Tune FastSQV" menu to be able to set some values without going to the fluidd/mainsail interface.
+4. Once you have added the configuration to your klipper configuration, restart Klipper.
 5. When the machine is back online, run the command `SET_INFILL_SQV SQV=<VALUE>`. This will define the SQV value you want to use during the infill. I suggest a value of `20` if your printer is capable of going very fast (eg. Voron, RatRig VCore-3, ...).
 
 Extra Step: 
@@ -31,7 +31,13 @@ Extra Step:
 You can update the SQV value for infill while it's printing by using the same command above. It will be applied during the next infill run. If you don't want to modify the infill SQV, just set the value to the same value as your default SQV.
 
 NOTE:
-* Ensure that the printer is perfectly tuned to handle high printing speed otherwise layer shift and other artifacts may occur during the printing process.
+* :warning: Ensure that the printer is perfectly tuned to handle high printing speed otherwise layer shift and other artifacts may occur during the printing process.
+* The `fast_infill.cfg` and `menu_fast_infill.cfg` files can be copied to the same folder as your `printer.cfg` and just add these sections there:
+    ```ini
+    [include fast_infill.cfg]
+    [include menu_fast_infill.cfg]
+    ```
+
 
 ## SuperSlicer
 

--- a/klipper/menu_fast_infill.cfg
+++ b/klipper/menu_fast_infill.cfg
@@ -1,59 +1,74 @@
-[menu __main __tune __square_corner_velocity]
+[menu __main tune_fastsqv]
+type: list
+name: Tune FastSQV
+index: 2
+
+[menu __main tune_fastsqv square_corner_velocity]
 type: input
-name: SQV: {menu.input}
+name: SQV Std   : {'%2d' % (menu.input)}
 input: {printer.toolhead.square_corner_velocity}
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={menu.input}
 
-[menu __main __tune __square_corner_velocity_infill]
+[menu __main tune_fastsqv square_corner_velocity_infill]
 type: input
-name: In SQV: {menu.input}
+name: Infill    : {'%2d' % (menu.input)}
 input: {printer.save_variables.variables.infill_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_INFILL_SQV SQV={menu.input}
 
-[menu __main __tune __square_corner_velocity_solid]
+[menu __main tune_fastsqv square_corner_velocity_solid]
 type: input
-name: Solid SQV: {menu.input}
+name: Solid     : {'%2d' % (menu.input)}
 input: {printer.save_variables.variables.solid_infill_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_SOLID_INFILL_SQV SQV={menu.input}
 
-[menu __main __tune __square_corner_velocity_top_solid]
+[menu __main tune_fastsqv square_corner_velocity_top_solid]
 type: input
-name: Top Solid SQV: {menu.input}
+name: Top Solid : {'%2d' % (menu.input)}
 input: {printer.save_variables.variables.top_solid_infill_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_TOP_SOLID_INFILL_SQV SQV={menu.input}
 
-[menu __main __tune __square_corner_velocity_internal_perimeter]
+[menu __main tune_fastsqv square_corner_velocity_internal_perimeter]
 type: input
-name: Int. Perimeter SQV: {menu.input}
+name: Int. Peri.: {'%2d' % (menu.input)}
 input: {printer.save_variables.variables.internal_perimeter_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_INTERNAL_PERIMETER_SQV SQV={menu.input}
 
-[menu __main __tune __square_corner_velocity_internal_bridge]
+[menu __main tune_fastsqv square_corner_velocity_internal_bridge]
 type: input
-name: Int. Bridge SQV: {menu.input}
-input: {printer.save_variables.variables.internal_perimeter_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
+name: Int. Brid.: {'%2d' % (menu.input)}
+input: {printer.save_variables.variables.internal_bridge_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
 input_step: 1
 input_min: 1
-input_max: 100
+input_max: 99
 gcode:
   SET_INTERNAL_BRIDGE_SQV SQV={menu.input}
+
+[menu __main tune_fastsqv square_corner_velocity_bridge_infill]
+type: input
+name: Br. Infill: {'%2d' % (menu.input)}
+input: {printer.save_variables.variables.bridge_infill_sqv | default(printer.configfile.settings.printer.square_corner_velocity, true) }
+input_step: 1
+input_min: 1
+input_max: 99
+gcode:
+  SET_BRIDGE_INFILL_SQV SQV={menu.input}

--- a/superslicer/FastSQV.py
+++ b/superslicer/FastSQV.py
@@ -44,6 +44,7 @@ with open(dest_file, "w") as of:
     of.write('_USE_SOLID_INFILL_SQV\n')
     of.write('_USE_TOP_SOLID_INFILL_SQV\n')
     of.write('_USE_INTERNAL_BRIDGE_SQV\n')
+    of.write('_USE_BRIDGE_INFILL_SQV\n')
     of.write('_USE_NORMAL_SQV\n')
     for line_Index in range(len(lines)):
         oline = lines[line_Index]


### PR DESCRIPTION
SuperSlicer plugin:
- Add missing start protection bridge_infill.

LCD Menu:
- Add missing menu bridge_infill.
- bad internal_perimeter_sqv variable in internal_bridge menu.
- input formatting to display correctly on 16-character wide screens.
- Don't use "__" prefixes from Klipper's default menus, for custom menus.
- The "Tune" menu is only available when printing. Use of a dedicated menu available all the time.